### PR TITLE
Add basic setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,18 @@
+from setuptools import setup
+
+setup(
+    name='tamproxy',
+    version='0.0.1',
+
+    description='TAMProxy Python Host',
+    url='https://github.com/mitchgu/TAMProxy-pyHost',
+
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Programming Language :: Python :: 2.7',
+    ],
+
+    keywords='maslab tamproxy',
+    packages=['tamproxy'],
+    install_requires=['numpy', 'pyserial>=3.0', 'PyYAML'],
+)


### PR DESCRIPTION
This now works for installing the requirements (on windows):

```
C:\Users\wiese\Repos\maslab\TAMProxy-pyHost>pip install . --user
Processing c:\users\wiese\repos\maslab\tamproxy-pyhost
Requirement already satisfied (use --upgrade to upgrade): numpy in c:\program files\python 3.5\lib\site-packages (from tamproxy==0.0.1)
Collecting pyserial>=3.0 (from tamproxy==0.0.1)
  Using cached pyserial-3.0.tar.gz
Collecting PyYAML (from tamproxy==0.0.1)
  Using cached PyYAML-3.11.tar.gz
Installing collected packages: pyserial, PyYAML, tamproxy
  Running setup.py install for pyserial
  Running setup.py install for PyYAML
  Running setup.py install for tamproxy
Successfully installed PyYAML pyserial tamproxy
```
