### PR TITLE
Make this not crash immediately on non-posix

### DIFF
--- a/tamproxy/comm/tamp_serial.py
+++ b/tamproxy/comm/tamp_serial.py
@@ -22,7 +22,8 @@ class TAMPSerial(serial.Serial):
                                          self.BAUD_RATE,
                                          timeout=0,
                                          write_timeout=0)
-        self.nonblocking()
+        if hasattr(self, 'nonblocking'):
+            self.nonblocking()
         if hello_packet: self.establish()
 
     def get_port(self):


### PR DESCRIPTION
Works on python 2, on windows #10
