### PR TITLE
Store raw word as returned from gyro, and display it in the test

### DIFF
--- a/gyro_read.py
+++ b/gyro_read.py
@@ -16,8 +16,8 @@ class GyroRead(SyncedSketch):
         if self.timer.millis() > 100:
             self.timer.reset()
             # Valid gyro status is [0,1], see datasheet on ST1:ST0 bits
-            print self.gyro.val, self.gyro.status
-            
+            print "{:6f}, raw: 0x{:08x} = 0b{:032b}".format(self.gyro.val, self.gyro.raw, self.gyro.raw)
+
 if __name__ == "__main__":
     sketch = GyroRead(1, -0.00001, 100)
     sketch.run()

--- a/tamproxy/devices/gyro.py
+++ b/tamproxy/devices/gyro.py
@@ -14,6 +14,7 @@ class Gyro(ContinuousReadDevice):
         self.status = None
         self.integrate = integrate
         self.time = None
+        self.raw = 0
         super(Gyro, self).__init__(tamproxy, integrate)
 
     def __repr__(self):
@@ -32,6 +33,8 @@ class Gyro(ContinuousReadDevice):
         # Assemble 32-bit returned value
         ret_word = ((ord(response[0])<<24) + (ord(response[1])<<16)
                     + (ord(response[2])<<8) + ord(response[3]))
+
+        self.raw = ret_word
         # Check status bits
         st0 = (ret_word >> 26) & 0x1
         st1 = (ret_word >> 27) & 0x1


### PR DESCRIPTION
We're getting some error packets from the gyro, and needed to diagnose them.

```
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0400ff = 0b00011110000001000000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0400ff = 0b00011110000001000000000011111111
26.262013, raw: 0x1e0400ff = 0b00011110000001000000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
26.262013, raw: 0x1e0200ff = 0b00011110000000100000000011111111
```

Where that binary word corresponds to:

![image](https://cloud.githubusercontent.com/assets/425260/12437179/817af1f0-bee9-11e5-9638-6f1cf3065b41.png)
