### PR TITLE
Fix gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .python-version
 # python junk
 *.pyc
+*.egg-info/
 # for generated config headers
 *.h
 # for logfiles               


### PR DESCRIPTION
`.egg-info/` is generated by doing `pip install -e .`, as in #2 
