### PR TITLE
Adds time-of-flight sensor support (VL53L0X)

### DIFF
--- a/tamproxy/config.yaml
+++ b/tamproxy/config.yaml
@@ -128,6 +128,7 @@ devices:
     tof:
         code:           T       # 0x54
         read_code:      R       # 0x52
+        enable_code:    E       # 0x45
 
 packet:
     start_byte:         0xF0

--- a/tamproxy/config.yaml
+++ b/tamproxy/config.yaml
@@ -125,6 +125,9 @@ devices:
     color:
         code:           C       # 0x43 (color sensor)
         read_code:      R       # 0x52
+    tof:
+        code:           T       # 0x54
+        read_code:      R       # 0x52
 
 packet:
     start_byte:         0xF0

--- a/tamproxy/devices/__init__.py
+++ b/tamproxy/devices/__init__.py
@@ -7,3 +7,4 @@ from .encoder import Encoder
 from .gyro import Gyro
 from .servo import Servo
 from .color import Color
+from .tof import TimeOfFlight

--- a/tamproxy/devices/tof.py
+++ b/tamproxy/devices/tof.py
@@ -1,0 +1,38 @@
+from .device import Device
+from .. import config as c
+
+# Retreives continuous time-of-flight distance measurement in millimeters.
+class TimeOfFlight(Device):
+
+    DEVICE_CODE = c.devices.tof.code
+    READ_CODE   = c.devices.tof.read_code
+
+    def __init__(self, tamproxy, xshut_pin, continuous=True):
+        self.dist = 0
+        self.xshut_pin = 0
+        super(TimeOfFlight, self).__init__(tamproxy)
+        while self.id is None: pass
+        if continuous:
+            self.start_continuous()
+
+    @property
+    def add_payload(self):
+        # Note: for now only supports one device on the bus
+        # TODO(gkanwar): Fix this using the method of bringing one
+        # chip up at a time and setting addresses
+        return self.DEVICE_CODE
+
+    def update(self):
+        self.tamp.send_request(self.id, self.READ_CODE, self.handle_update)
+
+    def start_continuous(self, weight=1):
+        self.tamp.send_request(self.id, self.READ_CODE, self.handle_update,
+                               continuous=True, weight=weight)
+
+    def stop_continuous(self):
+        self.tamp.send_request(self.id, self.READ_CODE, self.tamp.empty_callback,
+                               continuous=True, weight=1, remove=True)
+
+    def handle_update(self, request, response):
+        assert len(response) == 2
+        self.dist = (ord(response[0])<<8) + ord(response[1])

--- a/tof_read.py
+++ b/tof_read.py
@@ -11,8 +11,8 @@ from tamproxy.devices import TimeOfFlight
 class TimeOfFlightRead(SyncedSketch):
 
     # Set these to the digital inputs connected to each xshut pin
-    self.tof_pin = 20
-    self.tof2_pin = 21
+    tof_pin = 20
+    tof2_pin = 21
 
     def setup(self):
         # Add all ToFs

--- a/tof_read.py
+++ b/tof_read.py
@@ -4,16 +4,31 @@ from tamproxy.devices import TimeOfFlight
 # Print millimeter distance read. Time-of-flight VL53L0X sensor should be
 # connected to the I2C ports (SDA and SCL).
 
+# Your code should always set up all ToF sensors with unique ids (1-15) FIRST,
+# and only then enable them all. Otherwise they will walk over each other
+# on the I2C bus, since they will all have the same address.
+
 class TimeOfFlightRead(SyncedSketch):
 
+    # Set these to the digital inputs connected to each xshut pin
+    self.tof_pin = 20
+    self.tof2_pin = 21
+
     def setup(self):
-        self.tof = TimeOfFlight(self.tamp, 0)
+        # Add all ToFs
+        self.tof = TimeOfFlight(self.tamp, self.tof_pin, 1)
+        self.tof2 = TimeOfFlight(self.tamp, self.tof2_pin, 2)
+
+        # Now enable them all
+        self.tof.enable()
+        self.tof2.enable()
+        
         self.timer = Timer()
 
     def loop(self):
         if self.timer.millis() > 100:
             self.timer.reset()
-            print self.tof.dist, "mm"
+            print self.tof.dist, "mm", "/", self.tof2.dist, "mm"
 
 if __name__ == "__main__":
     sketch = TimeOfFlightRead(1, -0.00001, 100)

--- a/tof_read.py
+++ b/tof_read.py
@@ -1,0 +1,20 @@
+from tamproxy import Sketch, SyncedSketch, Timer
+from tamproxy.devices import TimeOfFlight
+
+# Print millimeter distance read. Time-of-flight VL53L0X sensor should be
+# connected to the I2C ports (SDA and SCL).
+
+class TimeOfFlightRead(SyncedSketch):
+
+    def setup(self):
+        self.tof = TimeOfFlight(self.tamp, 0)
+        self.timer = Timer()
+
+    def loop(self):
+        if self.timer.millis() > 100:
+            self.timer.reset()
+            print self.tof.dist, "mm"
+
+if __name__ == "__main__":
+    sketch = TimeOfFlightRead(1, -0.00001, 100)
+    sketch.run()


### PR DESCRIPTION
Supports two messages:
* Enable
* Read

Enable is necessary to support multiple ToF sensors, since they must be brought online one at a time and set to new I2C addresses.